### PR TITLE
Set cross-origin isolation headers

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,3 +1,4 @@
 /*
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Embedder-Policy: require-corp
+  Cross-Origin-Resource-Policy: same-origin

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin">
     <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp">
+    <meta http-equiv="Cross-Origin-Resource-Policy" content="same-origin">
     <title>chatfile-interface</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -4,10 +4,26 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const app = express();
+// Создаем роутер
+const router = express.Router();
 
-app.use(cors());
-app.use(express.json());
+// Настраиваем CORS с необходимыми заголовками
+router.use(cors({
+  origin: '*',
+  methods: ['GET', 'POST', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  credentials: true,
+}));
+
+// Добавляем middleware для установки заголовков безопасности
+router.use((req, res, next) => {
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+  res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+  next();
+});
+
+router.use(express.json());
 
 interface ChatRequest {
   messages: Array<{
@@ -21,9 +37,6 @@ interface ChatResponse {
   action?: 'create_file';
   filename?: string;
 }
-
-// Создаем роутер
-const router = express.Router();
 
 // Обработчик POST запросов к /api/chat
 router.post('/chat', async (req: express.Request<{}, {}, ChatRequest>, res: express.Response) => {
@@ -44,7 +57,4 @@ router.post('/chat', async (req: express.Request<{}, {}, ChatRequest>, res: expr
   }
 });
 
-// Подключаем роутер к приложению
-app.use('/api', router);
-
-export default app;
+export { router };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -8,6 +8,14 @@ dotenv.config();
 const app = express();
 const port = process.env.PORT || 3001;
 
+// Middleware для установки заголовков безопасности
+app.use((req, res, next) => {
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+  res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
+  next();
+});
+
 // Middleware для парсинга JSON
 app.use(express.json());
 


### PR DESCRIPTION
Added necessary headers to ensure cross-origin isolation for SharedArrayBuffer usage. Implemented middleware in the Express server to set `Cross-Origin-Opener-Policy` to `same-origin` and `Cross-Origin-Embedder-Policy` to `require-corp`. This change addresses potential issues with external scripts and resources that require these headers for proper functionality. [skip gpt_engineer]